### PR TITLE
add method to create new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 | all_collaborators    | List collaborator  details                        | `get_all_collaborators()`   |
 | all_milestones       | List milestone details                            | `get_all_milestones()`      |
 | all_forks            | List fork details                                 | `get_all_forks()`           |
+| create_repo| Creates new repo | `create_repo()`
 
 
 **Note: Refer `https://docs.github.com/en/rest/` for full list of APIs

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@
 | all_collaborators    | List collaborator  details                        | `get_all_collaborators()`   |
 | all_milestones       | List milestone details                            | `get_all_milestones()`      |
 | all_forks            | List fork details                                 | `get_all_forks()`           |
-| create_repo| Creates new repo | `create_repo()`
+| create_repo| Creates new repo | `create_repo()`|
+| create_fork | Creates fork of a repo | create_fork()
 
 
 **Note: Refer `https://docs.github.com/en/rest/` for full list of APIs

--- a/api_base.js
+++ b/api_base.js
@@ -4,11 +4,9 @@ function create_base(config){
   const api_base = axios.create({
 
    headers: { 
-    'Authorization': `Token ${
-        config.accessToken 
-      }`,
+    'Authorization': `Token ${config.accessToken}`,
     'auth':{
-      'username':config.username,
+    'username':config.username,
     'password':config.accessToken,
     } ,
     'Content-Type': 'application/x-www-form-urlencoded'
@@ -17,4 +15,26 @@ function create_base(config){
 return api_base;
 }
 
-export default create_base;
+const request_handler = (url,method,accessToken,user,data) =>{
+   const req = create_base({
+      accessToken: accessToken,
+      username: user
+    })
+   const config = data ?{
+      method: method,
+      url: url,
+      data:data,
+    }: {
+      method: method,
+      url: url,
+    };  
+  return req(config);
+}
+
+const api_url = {
+  base:'https://api.github.com',
+  create_repo: `/user/repos`,
+  fork_repo: `/repos/`
+}
+
+export {create_base,api_url,request_handler};

--- a/api_base.js
+++ b/api_base.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+function create_base(config){
+  const api_base = axios.create({
+
+   headers: { 
+    'Authorization': `Token ${
+        config.accessToken 
+      }`,
+    'auth':{
+      'username':config.username,
+    'password':config.accessToken,
+    } ,
+    'Content-Type': 'application/x-www-form-urlencoded'
+  },
+});
+return api_base;
+}
+
+export default create_base;

--- a/configs.js
+++ b/configs.js
@@ -135,4 +135,18 @@ export const Configs = {
   all_forks: { url: "repos/{owner}/{repo}/forks", all_pages: true },
 
   // contributor_commit: "repos/{owner}/{repo}/stats/contributors",
+
+  //create repo
+  create_repo: {
+    url: `https://api.github.com/user/repos`
+  },
+
+  //fork repo
+  create_fork: {
+    url:`https://api.github.com/repos/{owner}/{repo_name}/forks`,
+    data:{
+      owner: 'OWNER',
+      repo: 'REPO'
+    },
+  }
 };

--- a/example/index.js
+++ b/example/index.js
@@ -18,7 +18,15 @@ api.get_all_branches().then((res) => {
   console.log(`Branch count: ${res.length}`);
 });
 
-api.create_repo({ repo_name: "tester", private: false, accessToken: process.env.PERSONAL_ACCESS_TOKEN, user: process.env.USER })
+api.create_fork({owner:"koustov",repo_name:"json-graphql-parser",accessToken: process.env.PERSONAL_ACCESS_TOKEN})
+.then((res)=>{
+  console.log(res)
+})
+.catch((e)=>{
+  console.log(e);
+})
+
+api.create_repo({ repo_name: "tester1", private: false, accessToken: process.env.PERSONAL_ACCESS_TOKEN, user: process.env.USER })
 .then((res) => {
   console.log(res);
  })

--- a/example/index.js
+++ b/example/index.js
@@ -14,11 +14,25 @@ const api = new GitAPI(
   process.env.REPO
 );
 
+api.create({ repo_name: "tester1", private: false, accessToken: process.env.PERSONAL_ACCESS_TOKEN, user: process.env.USER },'create_repo')
+.then((res)=>{
+  console.log(res);
+}).catch(e=>{
+  console.log(e);
+})
+
+api.create({ repo_name: "css-builder",accessToken: process.env.PERSONAL_ACCESS_TOKEN, owner: 'koustov' },'create_fork')
+.then((res)=>{
+  console.log(res);
+}).catch(e=>{
+  console.log(e);
+})
+
 api.get_all_branches().then((res) => {
   console.log(`Branch count: ${res.length}`);
 });
 
-api.create_fork({owner:"koustov",repo_name:"json-graphql-parser",accessToken: process.env.PERSONAL_ACCESS_TOKEN})
+api.create_fork({owner:"koustov",repo_name:"css-builder",accessToken: process.env.PERSONAL_ACCESS_TOKEN})
 .then((res)=>{
   console.log(res)
 })

--- a/example/index.js
+++ b/example/index.js
@@ -8,7 +8,6 @@ dotenv.config({ path: ".env" });
 // api.repo = process.env.REPO;
 
 // OR
-
 const api = new GitAPI(
   process.env.PERSONAL_ACCESS_TOKEN,
   process.env.USER,
@@ -17,6 +16,14 @@ const api = new GitAPI(
 
 api.get_all_branches().then((res) => {
   console.log(`Branch count: ${res.length}`);
+});
+
+api.create_repo({ repo_name: "tester", private: false, accessToken: process.env.PERSONAL_ACCESS_TOKEN, user: process.env.USER })
+.then((res) => {
+  console.log(res);
+ })
+.catch(e => {
+  console.log(e)
 });
 
 api.get_all_collaborators().then((res) => {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import { Configs } from "./configs.js";
 import axios from "axios";
+import create_base from "./api_base.js";
 
 export const GitAPI = class API {
   #_accessToken = "";
@@ -26,7 +27,7 @@ export const GitAPI = class API {
 
   request(config, page_number, user, repo, accessToken) {
     const options = {
-      method: "GET",
+      method: 'GET',
       // 'username': data.login,
       headers: {
         Accept: "application/vnd.github.v3+json",
@@ -37,9 +38,8 @@ export const GitAPI = class API {
     };
 
     if (accessToken) {
-      options.headers["authorization"] = `token ${
-        accessToken || this.#_accessToken
-      }`;
+      options.headers["authorization"] = `token ${accessToken || this.#_accessToken
+        }`;
     }
 
     let final_url = config.url
@@ -70,6 +70,39 @@ export const GitAPI = class API {
       });
   }
 
+
+  post_req(name,accessToken,user) {
+    const config = {
+      method: 'post',
+      url: 'https://api.github.com/user/repos',
+      data: {
+        "name": name,
+        "private": false
+      }
+    };
+    const req = create_base({
+      accessToken: accessToken || this.#_accessToken,
+      username: user || this.#_user
+    })
+    return req(config);
+
+  }
+
+  //create branch
+  create_repo = (config) => {
+     
+    const req_method = this.post_req;
+    return new Promise(async function (resolve, reject) {
+      try {
+        const result = await req_method(config.repo_name,config.accessToken,config.user);
+        resolve(result);
+      } catch (e) {
+        reject(e);
+      }
+     
+    })
+  }
+
   get_all_pages = (config) => {
     const req_method = this.request;
     const req_access_token = this.#_accessToken;
@@ -86,7 +119,8 @@ export const GitAPI = class API {
           current_page_number,
           req_user,
           req_repo,
-          req_access_token
+          req_access_token,
+
         );
         const found_result = res.length > 0;
         // console.log(res.length);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { Configs } from "./configs.js";
 import axios from "axios";
-import {api_url, create_base, request_handler} from "./api_base.js";
+import { api_url, create_base, request_handler } from "./api_base.js";
 
 export const GitAPI = class API {
   #_accessToken = "";
@@ -71,41 +71,55 @@ export const GitAPI = class API {
   }
 
 
-  // post_req(accessToken,user,data,url) {
-  //   console.log(data)
-  //   const config = {
-  //     method: 'post',
-  //     url: url,
-  //     data:data,
-  //   };
-  //   const req = create_base({
-  //     accessToken: accessToken || this.#_accessToken,
-  //     username: user || this.#_user
-  //   })
-  //   return req(config);
-
-  // }
-
-
-
-  create_fork =(config) =>{
+  create = async (config, type) => {
     const req_method = request_handler;
-    const data = {
-      owner: 'OWNER',
-      repo: 'REPO'
+    let data;
+    let url;
+    switch (type) {
+      case 'create_repo':
+        data = {
+          "name": config.repo_name,
+          "private": false
+        };
+        url = Configs[type].url;
+        break;
+      case 'create_fork':
+        data = Configs[type].data;
+        const inter = Configs[type].url.replace(`{owner}`, config.owner);
+        url = inter.replace(`{repo_name}`, config.repo_name);
+        break;
     }
- 
-    return new Promise(async function(resolve,reject){
-      try{
+
+    try {
+      const result = await req_method(
+        url,
+        'POST',
+        config.accessToken,
+        config.owner,
+        data
+      );
+      return result;
+    } catch (e) {
+      return e;
+    }
+  }
+
+  create_fork = (config) => {
+    const req_method = request_handler;
+   const data = Configs['create_fork'].data;
+  const inter = Configs['create_fork'].url.replace(`{owner}`, config.owner);
+  const url = inter.replace(`{repo_name}`, config.repo_name);
+    return new Promise(async function (resolve, reject) {
+      try {
         const result = await req_method(
-          `${api_url.base}${api_url.fork_repo}${config.owner}/${config.repo_name}/forks`,
+          url,
           'POST',
           config.accessToken,
           config.owner,
           data,
-          );
+        );
         resolve(result);
-      }catch(e){
+      } catch (e) {
         reject(e);
       }
     })
@@ -113,27 +127,27 @@ export const GitAPI = class API {
 
   // create repo
   create_repo = (config) => {
-  
-    const req_method = request_handler;
-    const data =  {
-        "name": config.repo_name,
-        "private": false
-      }
 
+    const req_method = request_handler;
+    const data = {
+      "name": config.repo_name,
+      "private": false
+    }
+    const url = Configs[type].url;
     return new Promise(async function (resolve, reject) {
       try {
         const result = await req_method(
-          `${api_url.base}${api_url.create_repo}`,
+          url,
           'POST',
           config.accessToken,
           config.owner,
           data,
-          );
+        );
         resolve(result);
       } catch (e) {
         reject(e);
       }
-     
+
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { Configs } from "./configs.js";
 import axios from "axios";
-import create_base from "./api_base.js";
+import {api_url, create_base, request_handler} from "./api_base.js";
 
 export const GitAPI = class API {
   #_accessToken = "";
@@ -71,30 +71,64 @@ export const GitAPI = class API {
   }
 
 
-  post_req(name,accessToken,user) {
-    const config = {
-      method: 'post',
-      url: 'https://api.github.com/user/repos',
-      data: {
-        "name": name,
-        "private": false
-      }
-    };
-    const req = create_base({
-      accessToken: accessToken || this.#_accessToken,
-      username: user || this.#_user
-    })
-    return req(config);
+  // post_req(accessToken,user,data,url) {
+  //   console.log(data)
+  //   const config = {
+  //     method: 'post',
+  //     url: url,
+  //     data:data,
+  //   };
+  //   const req = create_base({
+  //     accessToken: accessToken || this.#_accessToken,
+  //     username: user || this.#_user
+  //   })
+  //   return req(config);
 
+  // }
+
+
+
+  create_fork =(config) =>{
+    const req_method = request_handler;
+    const data = {
+      owner: 'OWNER',
+      repo: 'REPO'
+    }
+ 
+    return new Promise(async function(resolve,reject){
+      try{
+        const result = await req_method(
+          `${api_url.base}${api_url.fork_repo}${config.owner}/${config.repo_name}/forks`,
+          'POST',
+          config.accessToken,
+          config.owner,
+          data,
+          );
+        resolve(result);
+      }catch(e){
+        reject(e);
+      }
+    })
   }
 
-  //create branch
+  // create repo
   create_repo = (config) => {
-     
-    const req_method = this.post_req;
+  
+    const req_method = request_handler;
+    const data =  {
+        "name": config.repo_name,
+        "private": false
+      }
+
     return new Promise(async function (resolve, reject) {
       try {
-        const result = await req_method(config.repo_name,config.accessToken,config.user);
+        const result = await req_method(
+          `${api_url.base}${api_url.create_repo}`,
+          'POST',
+          config.accessToken,
+          config.owner,
+          data,
+          );
         resolve(result);
       } catch (e) {
         reject(e);


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently, users can't create a repo using this library

**Describe the solution you'd like**
Build an API that allows users to create Github repo using this library

**Addition to codebase**
1. a new function called create_base which is a generic axios method at api_base.js
2. post_req method to create post instance of axios at index.js
3. create_repo method to create GHU repo at index.js
4. general create method

**What improvements** 
1. proper document for create_repo method (TDT)

Describe alternatives you've considered

